### PR TITLE
Change repository name to mqtt-bridge

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,8 +1,8 @@
 package app
 
 import (
-	"github.com/dnstapir/mqtt-sender/app/log"
-	"github.com/dnstapir/mqtt-sender/app/bridge"
+	"github.com/dnstapir/mqtt-bridge/app/log"
+	"github.com/dnstapir/mqtt-bridge/app/bridge"
 )
 
 type App struct {

--- a/app/bridge/bridge.go
+++ b/app/bridge/bridge.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nats-io/nats.go"
     "github.com/santhosh-tekuri/jsonschema/v6"
 
-	"github.com/dnstapir/mqtt-sender/app/log"
+	"github.com/dnstapir/mqtt-bridge/app/log"
 )
 
 type bridgeOpt func(*tapirBridge) error

--- a/cmd/mqtt-sender/main.go
+++ b/cmd/mqtt-sender/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/dnstapir/mqtt-sender/app"
+	"github.com/dnstapir/mqtt-bridge/app"
 )
 
 func main() {
@@ -86,16 +86,16 @@ func main() {
 
 	flag.Parse()
 
-	klfPath := os.Getenv("TAPIR_MQTT_SENDER_KLF")
+	klfPath := os.Getenv("TAPIR_MQTT_BRIDGE_KLF")
 	if klfPath != "" {
 		application.MqttTlsKlfPath = klfPath
 	}
 
     application.Bridges = []app.Bridge{br}
 
-	fmt.Println("###### starting mqtt-sender...")
+	fmt.Println("###### starting mqtt-bridge...")
 	application.Run()
 
 	s := <-c
-	fmt.Println(fmt.Sprintf("###### mqtt-sender got signal '%s', exiting...", s))
+	fmt.Println(fmt.Sprintf("###### mqtt-bridge got signal '%s', exiting...", s))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dnstapir/mqtt-sender
+module github.com/dnstapir/mqtt-bridge
 
 go 1.23.6
 

--- a/misc/examples/downbound.sh
+++ b/misc/examples/downbound.sh
@@ -1,6 +1,6 @@
 # An example deployment of how to bridge from NATS->MQTT
 
-./bin/mqtt-sender -mqtt-url "tls://mqtt.dev.dnstapir.se:8883" \
+./bin/mqtt-bridge -mqtt-url "tls://mqtt.dev.dnstapir.se:8883" \
     -debug \
     -direction down
     -data-schema misc/accept-all-schema.json

--- a/misc/examples/upbound.sh
+++ b/misc/examples/upbound.sh
@@ -1,6 +1,6 @@
 # An example deployment of how to bridge from MQTT->NATS
 
-mqtt-sender -mqtt-url "tls://mqtt.dev.dnstapir.se:8883" \
+mqtt-bridge -mqtt-url "tls://mqtt.dev.dnstapir.se:8883" \
     -debug \
     -direction up \
     -data-key certs/eldorado-jet.pub.json \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified the application's branding by renaming it from "mqtt-sender" to "mqtt-bridge" across startup messages, environment variables, and logging outputs.

- **Chores**
  - Updated module declarations, import references, and executable commands in example scripts to align with the new application identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->