### PR TITLE
Override NATS and MQTT URLs with env vars

### DIFF
--- a/cmd/mqtt-bridge/main.go
+++ b/cmd/mqtt-bridge/main.go
@@ -13,6 +13,9 @@ import (
 	"github.com/dnstapir/mqtt-bridge/app"
 )
 
+const c_ENVVAR_OVERRIDE_MQTT_URL = "DNSTAPIR_BRIDGE_MQTT_URL"
+const c_ENVVAR_OVERRIDE_NATS_URL = "DNSTAPIR_BRIDGE_NATS_URL"
+
 func main() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
@@ -39,7 +42,17 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf("Read conf %+v\n", application)
+    envMqttUrl, overrideMqttUrl := os.LookupEnv(c_ENVVAR_OVERRIDE_MQTT_URL)
+    if overrideMqttUrl {
+        application.MqttUrl = envMqttUrl
+    }
+
+    envNatsUrl, overrideNatsUrl := os.LookupEnv(c_ENVVAR_OVERRIDE_NATS_URL)
+    if overrideNatsUrl {
+        application.NatsUrl = envNatsUrl
+    }
+
+	//fmt.Printf("Read conf %+v\n", application)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
fix #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for overriding MQTT and NATS URLs via environment variables. If these environment variables are set, their values will be used instead of the configuration file settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->