### PR TITLE
Use explicit package name when cleaning up containers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,4 +33,5 @@ jobs:
       - name: Delete untagged containers
         uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4
         with:
+          packages: dnstapir/mqtt-bridge
           delete-untagged: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited automated cleanup to untagged containers from the MQTT bridge package.
  * No other container workflow behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->